### PR TITLE
Don't explicitly set a flink kafka partitioner

### DIFF
--- a/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanToStructuredTraceGroupingJob.java
+++ b/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanToStructuredTraceGroupingJob.java
@@ -108,8 +108,11 @@ public class RawSpanToStructuredTraceGroupingJob implements PlatformBackgroundJo
     SerializationSchema<StructuredTrace> serializationSchema = new RegistryBasedAvroSerde<>(
         outputTopic, StructuredTrace.class, sinkSchemaRegistryConfig);
     outputStream.addSink(
-        FlinkUtils.getFlinkKafkaProducer(outputTopic, serializationSchema, kafkaProducerConfig,
-            logFailuresOnly));
+        FlinkUtils
+            .getFlinkKafkaProducer(outputTopic, serializationSchema,
+                null/* By specifying null this will default to kafka producer's default partitioner i.e. round-robin*/,
+                kafkaProducerConfig,
+                logFailuresOnly));
     environment.execute("raw-spans-grouper");
   }
 


### PR DESCRIPTION
Currently the FlinkFixedPartitioner uses a static mapping i.e. subtask_id % num_partitions and the subtask_id is dependent on the *parallelism* config specified.
This has 2 problems:
- The parallelism is specified for the producer (upstream job) and can be different from the downstream job.
- The number of partitions could be different across the upstream and downstream jobs 

To avoid skew by not explicitly specifying a partitioner flink will fallback on Kafka producer's default partitioning strategy - which is round-robin.  