### PR TITLE
rename state stores

### DIFF
--- a/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
+++ b/raw-spans-grouper/src/main/java/org/hypertrace/core/rawspansgrouper/RawSpanGrouperConstants.java
@@ -5,8 +5,8 @@ public class RawSpanGrouperConstants {
   public static final String OUTPUT_TOPIC_CONFIG_KEY = "output.topic";
   public static final String SPAN_GROUPBY_SESSION_WINDOW_INTERVAL_CONFIG_KEY = "span.groupby.session.window.interval";
   public static final String RAW_SPANS_GROUPER_JOB_CONFIG = "raw-spans-grouper-job-config";
-  public static final String INFLIGHT_TRACE_STORE = "inflight-trace-store";
-  public static final String TRACE_EMIT_TRIGGER_STORE = "trace-emit-trigger-store";
+  public static final String INFLIGHT_TRACE_STORE = "inflight-traces-store";
+  public static final String TRACE_EMIT_TRIGGER_STORE = "traces-emit-trigger-store";
   public static final String OUTPUT_TOPIC_PRODUCER = "output-topic-producer";
   public static final String SPANS_PER_TRACE_METRIC = "spans_per_trace";
   public static final String TRACE_CREATION_TIME = "trace.creation.time";


### PR DESCRIPTION
In order to make the deployment to prod seamless the state stores are renamed. This is needed as at some point we rolled out the raw-spans-grouper and rolled it back leaving old state stores that are incompatible with the new version. Alternatively we can reset the app but this solution avoids having to manually reset.